### PR TITLE
Add automated cross-platform release packaging workflow

### DIFF
--- a/.github/workflows/plugin-build-platform.yml
+++ b/.github/workflows/plugin-build-platform.yml
@@ -1,0 +1,116 @@
+name: Build plugin (platform)
+
+# Reusable per-platform build: checkout, submodules, Rust/cargo setup, the
+# cached lore crate build, and the CMake configure/build that produces
+# addons/godot-lore-plugin/<platform>/. Called by plugin-build.yml (routine
+# CI validation, fast settings) and plugin-release.yml (real release
+# artifacts, real settings) with different inputs rather than duplicating
+# these steps in both files.
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        description: Runner label (e.g. windows-latest)
+        required: true
+        type: string
+      platform_dir:
+        description: addons/godot-lore-plugin/<platform> staging directory this build populates
+        required: true
+        type: string
+      cargo_profile:
+        description: Cargo profile to build the lore crate with (release or release-lto)
+        required: true
+        type: string
+      rust_targets:
+        description: Extra Rust targets to install (space-separated), beyond the host default
+        required: false
+        type: string
+        default: ""
+      cmake_extra_args:
+        description: Extra arguments passed to the CMake configure step
+        required: false
+        type: string
+        default: ""
+      timeout_minutes:
+        description: Job timeout in minutes
+        required: false
+        type: number
+        default: 60
+      upload_artifact:
+        description: Whether to upload platform_dir as a workflow artifact
+        required: false
+        type: boolean
+        default: false
+      artifact_name:
+        description: Name for the uploaded artifact (required when upload_artifact is true)
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  build:
+    runs-on: ${{ inputs.os }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Both submodules are needed for a full build. Neither has nested
+      # submodules of its own, so no --recursive.
+      - name: Checkout submodules
+        run: git submodule update --init third_party/godot-cpp third_party/lore
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ inputs.rust_targets }}
+
+      - name: Cache cargo registry and build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: third_party/lore
+
+      # lore only ever changes when this commit changes, so a hit here lets
+      # CMakeLists.txt's lore_cargo_build target skip cargo entirely instead
+      # of relying on cargo's own (slower, always-partial) fingerprinting.
+      - name: Resolve lore submodule commit
+        id: lore-sha
+        shell: bash
+        run: echo "sha=$(git -C third_party/lore rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore cached lore artifact
+        id: lore-artifact-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: build/lore
+          key: lore-artifact-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cargo_profile }}-${{ steps.lore-sha.outputs.sha }}
+
+      - name: Configure
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DLORE_CARGO_PROFILE=${{ inputs.cargo_profile }} ${{ inputs.cmake_extra_args }}
+
+      - name: Build
+        run: cmake --build build --config Release
+
+      - name: Save lore artifact cache
+        if: steps.lore-artifact-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: build/lore
+          key: lore-artifact-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cargo_profile }}-${{ steps.lore-sha.outputs.sha }}
+
+      # Filename-agnostic: single-arch macOS output isn't named the same as
+      # the "universal" release artifact, so just confirm something staged.
+      - name: Verify staged artifacts exist
+        shell: bash
+        run: |
+          ls -la "${{ inputs.platform_dir }}"
+          test -n "$(find "${{ inputs.platform_dir }}" -maxdepth 1 -iname 'godot-lore-plugin*' -print -quit)"
+          test -n "$(find "${{ inputs.platform_dir }}" -maxdepth 1 \( -iname 'lore.dll' -o -iname 'liblore.*' \) -print -quit)"
+
+      - name: Upload build artifact
+        if: inputs.upload_artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: ${{ inputs.platform_dir }}

--- a/.github/workflows/plugin-build-platform.yml
+++ b/.github/workflows/plugin-build-platform.yml
@@ -23,7 +23,7 @@ on:
         required: true
         type: string
       rust_targets:
-        description: Extra Rust targets to install (space-separated), beyond the host default
+        description: Extra Rust targets to install (comma-separated, per dtolnay/rust-toolchain), beyond the host default
         required: false
         type: string
         default: ""

--- a/.github/workflows/plugin-build-platform.yml
+++ b/.github/workflows/plugin-build-platform.yml
@@ -99,14 +99,13 @@ jobs:
           path: build/lore
           key: lore-artifact-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cargo_profile }}-${{ steps.lore-sha.outputs.sha }}
 
-      # Filename-agnostic: single-arch macOS output isn't named the same as
-      # the "universal" release artifact, so just confirm something staged.
+      # See scripts/verify-platform-package.sh for what "valid" means here
+      # and why the checks are filename-agnostic.
       - name: Verify staged artifacts exist
         shell: bash
         run: |
           ls -la "${{ inputs.platform_dir }}"
-          test -n "$(find "${{ inputs.platform_dir }}" -maxdepth 1 -iname 'godot-lore-plugin*' -print -quit)"
-          test -n "$(find "${{ inputs.platform_dir }}" -maxdepth 1 \( -iname 'lore.dll' -o -iname 'liblore.*' \) -print -quit)"
+          bash scripts/verify-platform-package.sh "${{ inputs.platform_dir }}"
 
       - name: Upload build artifact
         if: inputs.upload_artifact

--- a/.github/workflows/plugin-build.yml
+++ b/.github/workflows/plugin-build.yml
@@ -2,7 +2,7 @@ name: Validate plugin build
 
 # Full build of the GDExtension itself (godot-cpp + the lore crate + the
 # lore_ffi wrapper + godot-lore-plugin), on all three platforms the addon
-# targets.
+# targets, via the reusable per-platform build workflow.
 #
 # This validates that the plugin *compiles and links*, not that it produces
 # the exact shippable release artifact: macOS builds a single native arch
@@ -11,7 +11,8 @@ name: Validate plugin build
 # optimize/codegen/link pass can't be cached/made incremental and costs
 # ~20+ min per architecture regardless of dependency cache hits. A real
 # distributable macOS universal binary still requires the plain, override-free
-# `cmake -B build -DCMAKE_BUILD_TYPE=Release` README.md documents.
+# `cmake -B build -DCMAKE_BUILD_TYPE=Release` README.md documents — see
+# plugin-release.yml, which builds the real release artifact.
 
 on:
   push:
@@ -23,6 +24,7 @@ on:
       - third_party/godot-cpp
       - third_party/lore
       - .github/workflows/plugin-build.yml
+      - .github/workflows/plugin-build-platform.yml
   pull_request:
     paths:
       - src/**
@@ -31,10 +33,8 @@ on:
       - third_party/godot-cpp
       - third_party/lore
       - .github/workflows/plugin-build.yml
+      - .github/workflows/plugin-build-platform.yml
   workflow_dispatch:
-
-env:
-  LORE_CARGO_PROFILE: release
 
 jobs:
   cmake-build:
@@ -59,63 +59,13 @@ jobs:
             rust_targets: ""
             cmake_extra_args: "-DCMAKE_OSX_ARCHITECTURES=arm64"
             timeout_minutes: 60
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: ${{ matrix.timeout_minutes }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      # Both submodules are needed for a full build, unlike
-      # lore-crate-build.yml. Neither has nested submodules of its own, so
-      # no --recursive.
-      - name: Checkout submodules
-        run: git submodule update --init third_party/godot-cpp third_party/lore
-
-      - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.rust_targets }}
-
-      - name: Cache cargo registry and build artifacts
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: third_party/lore
-
-      # lore only ever changes when this commit changes, so a hit here lets
-      # CMakeLists.txt's lore_cargo_build target skip cargo entirely instead
-      # of relying on cargo's own (slower, always-partial) fingerprinting.
-      - name: Resolve lore submodule commit
-        id: lore-sha
-        shell: bash
-        run: echo "sha=$(git -C third_party/lore rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
-      - name: Restore cached lore artifact
-        id: lore-artifact-cache
-        uses: actions/cache/restore@v4
-        with:
-          path: build/lore
-          key: lore-artifact-${{ runner.os }}-${{ runner.arch }}-${{ env.LORE_CARGO_PROFILE }}-${{ steps.lore-sha.outputs.sha }}
-
-      # release, not release-lto — see file header. Don't pass this (or the
+    uses: ./.github/workflows/plugin-build-platform.yml
+    with:
+      os: ${{ matrix.os }}
+      platform_dir: ${{ matrix.platform_dir }}
+      # release, not release-lto — see file header. Don't use this (or the
       # macOS arch override) when building a real release artifact.
-      - name: Configure
-        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DLORE_CARGO_PROFILE=${{ env.LORE_CARGO_PROFILE }} ${{ matrix.cmake_extra_args }}
-
-      - name: Build
-        run: cmake --build build --config Release
-
-      - name: Save lore artifact cache
-        if: steps.lore-artifact-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: build/lore
-          key: lore-artifact-${{ runner.os }}-${{ runner.arch }}-${{ env.LORE_CARGO_PROFILE }}-${{ steps.lore-sha.outputs.sha }}
-
-      # Filename-agnostic: single-arch macOS output isn't named the same as
-      # the "universal" release artifact, so just confirm something staged.
-      - name: Verify staged artifacts exist
-        shell: bash
-        run: |
-          ls -la "${{ matrix.platform_dir }}"
-          test -n "$(find "${{ matrix.platform_dir }}" -maxdepth 1 -iname 'godot-lore-plugin*' -print -quit)"
-          test -n "$(find "${{ matrix.platform_dir }}" -maxdepth 1 \( -iname 'lore.dll' -o -iname 'liblore.*' \) -print -quit)"
+      cargo_profile: release
+      rust_targets: ${{ matrix.rust_targets }}
+      cmake_extra_args: ${{ matrix.cmake_extra_args }}
+      timeout_minutes: ${{ matrix.timeout_minutes }}

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -29,22 +29,37 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.resolve.outputs.version }}
+      is_prerelease: ${{ steps.resolve.outputs.is_prerelease }}
     steps:
       - name: Resolve and validate version
         id: resolve
         shell: bash
         run: |
+          # Same SemVer pre-release/RC suffix shape used both to validate
+          # workflow_dispatch input and to decide the release's "Pre-release"
+          # flag below - a version has this shape if and only if it should
+          # be marked prerelease.
+          semver_prerelease_re='^v[0-9]+\.[0-9]+\.[0-9]+-[0-9A-Za-z][0-9A-Za-z.-]*$'
+
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             version="${{ inputs.version }}"
-            if ! [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-[0-9A-Za-z][0-9A-Za-z.-]*$ ]]; then
+            if ! [[ "$version" =~ $semver_prerelease_re ]]; then
               echo "::error::Manual dispatch requires a version with a SemVer pre-release/RC suffix (e.g. v0.3.0-rc1) to keep disposable test runs distinct from real releases. Got: '$version'"
               exit 1
             fi
           else
             version="${{ github.ref_name }}"
           fi
-          echo "Resolved release version: $version"
+
+          if [[ "$version" =~ $semver_prerelease_re ]]; then
+            is_prerelease=true
+          else
+            is_prerelease=false
+          fi
+
+          echo "Resolved release version: $version (prerelease: $is_prerelease)"
           echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "is_prerelease=$is_prerelease" >> "$GITHUB_OUTPUT"
 
   build:
     needs: resolve-version
@@ -166,9 +181,14 @@ jobs:
           set -euo pipefail
           version="${{ needs.resolve-version.outputs.version }}"
           zip_name="${{ steps.zip.outputs.zip_name }}"
+          prerelease_flag=()
+          if [ "${{ needs.resolve-version.outputs.is_prerelease }}" = "true" ]; then
+            prerelease_flag+=(--prerelease)
+          fi
           gh release create "$version" "$zip_name" \
             --repo "${{ github.repository }}" \
             --target "${{ github.sha }}" \
             --title "$version" \
             --draft \
-            --generate-notes
+            --generate-notes \
+            "${prerelease_flag[@]}"

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -89,3 +89,65 @@ jobs:
       timeout_minutes: ${{ matrix.timeout_minutes }}
       upload_artifact: true
       artifact_name: ${{ matrix.artifact_name }}
+
+  package:
+    # needs: build waits for every matrix leg; if any platform failed, this
+    # job is skipped entirely rather than assembling a zip that's silently
+    # missing a platform. No if: always() override - that's deliberate.
+    needs: [resolve-version, build]
+    runs-on: ubuntu-latest
+    outputs:
+      zip_name: ${{ steps.zip.outputs.zip_name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # LICENSE/THIRDPARTY.md live at the repo root; CMakeLists.txt mirrors
+      # them into addons/godot-lore-plugin/ as a local post-build step, but
+      # that copy is gitignored (a build byproduct, not committed there), so
+      # a fresh checkout alone doesn't produce them at the path that ships.
+      - name: Copy root LICENSE/THIRDPARTY.md into the addon folder
+        run: cp LICENSE THIRDPARTY.md addons/godot-lore-plugin/
+
+      # No name/pattern: downloads every artifact from this run (just the
+      # three platform builds at this point), each into its own directory
+      # named after the artifact - windows/linux/macos, matching the
+      # subfolder layout godot-lore-plugin.gdextension expects exactly.
+      - name: Download platform artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: addons/godot-lore-plugin
+
+      # Same filename-agnostic style as plugin-build-platform.yml's own
+      # per-platform check, extended to the whole assembled tree.
+      - name: Verify assembled package
+        shell: bash
+        run: |
+          set -euo pipefail
+          for platform_dir in addons/godot-lore-plugin/windows addons/godot-lore-plugin/linux addons/godot-lore-plugin/macos; do
+            echo "Checking $platform_dir"
+            ls -la "$platform_dir"
+            test -n "$(find "$platform_dir" -maxdepth 1 -iname 'godot-lore-plugin*' -print -quit)"
+            test -n "$(find "$platform_dir" -maxdepth 1 \( -iname 'lore.dll' -o -iname 'liblore.*' \) -print -quit)"
+          done
+          test -f addons/godot-lore-plugin/godot-lore-plugin.gdextension
+          test -f addons/godot-lore-plugin/LICENSE
+          test -f addons/godot-lore-plugin/THIRDPARTY.md
+
+      # addons/ prefix baked into the zip (not just godot-lore-plugin/) so
+      # extracting at a project's root drops it straight into addons/.
+      - name: Zip release package
+        id: zip
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ needs.resolve-version.outputs.version }}"
+          zip_name="godot-lore-plugin-${version}.zip"
+          zip -r "$zip_name" addons/godot-lore-plugin
+          echo "zip_name=$zip_name" >> "$GITHUB_OUTPUT"
+
+      - name: Upload release zip artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.zip.outputs.zip_name }}
+          path: ${{ steps.zip.outputs.zip_name }}

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -118,8 +118,9 @@ jobs:
         with:
           path: addons/godot-lore-plugin
 
-      # Same filename-agnostic style as plugin-build-platform.yml's own
-      # per-platform check, extended to the whole assembled tree.
+      # Same shared per-platform check plugin-build-platform.yml uses
+      # (scripts/verify-platform-package.sh), extended to the whole
+      # assembled tree.
       - name: Verify assembled package
         shell: bash
         run: |
@@ -127,8 +128,7 @@ jobs:
           for platform_dir in addons/godot-lore-plugin/windows addons/godot-lore-plugin/linux addons/godot-lore-plugin/macos; do
             echo "Checking $platform_dir"
             ls -la "$platform_dir"
-            test -n "$(find "$platform_dir" -maxdepth 1 -iname 'godot-lore-plugin*' -print -quit)"
-            test -n "$(find "$platform_dir" -maxdepth 1 \( -iname 'lore.dll' -o -iname 'liblore.*' \) -print -quit)"
+            bash scripts/verify-platform-package.sh "$platform_dir"
           done
           test -f addons/godot-lore-plugin/godot-lore-plugin.gdextension
           test -f addons/godot-lore-plugin/LICENSE

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -89,10 +89,20 @@ jobs:
             # lipo then merges.
             rust_targets: "x86_64-apple-darwin,aarch64-apple-darwin"
             cmake_extra_args: ""
-            # Dual-arch release-lto easily exceeds CI validation's 60-minute
-            # budget; no real number is on record yet for this repo, so
-            # start generous and tune down once a real run's timing is known.
-            timeout_minutes: 150
+            # Cold-cache (no prior release-lto cache entry for this Lore SHA
+            # on this git ref) is the case that matters: GitHub Actions cache
+            # scoping is per-ref, and main never populates a release-lto
+            # entry (its CI validation build uses the fast `release` profile
+            # only), so every real vX.Y.Z tag push starts cold here, not just
+            # the first release after a Lore submodule bump. Two observed
+            # cold-cache runs, both spent almost entirely in the single
+            # "Build" step: rc1 1h48m24s, rc2 2h0m42s. 180 min leaves ~1h
+            # (~50%) margin over the worst of those two, versus ~29 min
+            # (~24%) at the previous 150 - enough cushion for the known
+            # variance of shared macOS hosted runners without being
+            # arbitrarily large. Re-tune if a real cold-cache release run
+            # comes in meaningfully over ~2h.
+            timeout_minutes: 180
             artifact_name: macos
     uses: ./.github/workflows/plugin-build-platform.yml
     with:

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -96,6 +96,8 @@ jobs:
     # missing a platform. No if: always() override - that's deliberate.
     needs: [resolve-version, build]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       zip_name: ${{ steps.zip.outputs.zip_name }}
     steps:
@@ -151,3 +153,22 @@ jobs:
         with:
           name: ${{ steps.zip.outputs.zip_name }}
           path: ${{ steps.zip.outputs.zip_name }}
+
+      # --target pins the release to the exact commit this run built (the
+      # tag itself doesn't exist yet for a workflow_dispatch RC run), rather
+      # than defaulting to the tip of the default branch. --draft leaves the
+      # human-review checkpoint in place; --generate-notes uses GitHub's
+      # auto-generated notes per the spec, no hand-authored body required.
+      - name: Create draft GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          version="${{ needs.resolve-version.outputs.version }}"
+          zip_name="${{ steps.zip.outputs.zip_name }}"
+          gh release create "$version" "$zip_name" \
+            --repo "${{ github.repository }}" \
+            --target "${{ github.sha }}" \
+            --title "$version" \
+            --draft \
+            --generate-notes

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -136,13 +136,26 @@ jobs:
           path: addons/godot-lore-plugin
 
       # Same shared per-platform check plugin-build-platform.yml uses
-      # (scripts/verify-platform-package.sh), extended to the whole
-      # assembled tree.
+      # (scripts/verify-platform-package.sh). Platform directories are
+      # discovered from what the download step above actually populated
+      # (one per platform, matching the build job's matrix artifact_name
+      # entries) rather than re-listing windows/linux/macos by hand a
+      # second time. The count check preserves the existing "fail loudly if
+      # a platform is missing" guarantee even though the names themselves
+      # are no longer enumerated here.
       - name: Verify assembled package
         shell: bash
         run: |
           set -euo pipefail
-          for platform_dir in addons/godot-lore-plugin/windows addons/godot-lore-plugin/linux addons/godot-lore-plugin/macos; do
+          shopt -s nullglob
+          platform_dirs=(addons/godot-lore-plugin/*/)
+          expected_platform_count=3
+          if [ "${#platform_dirs[@]}" -ne "$expected_platform_count" ]; then
+            echo "::error::Expected $expected_platform_count platform directories under addons/godot-lore-plugin/, found ${#platform_dirs[@]}: ${platform_dirs[*]}"
+            exit 1
+          fi
+          for platform_dir in "${platform_dirs[@]}"; do
+            platform_dir="${platform_dir%/}"
             echo "Checking $platform_dir"
             ls -la "$platform_dir"
             bash scripts/verify-platform-package.sh "$platform_dir"

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -101,7 +101,9 @@ jobs:
             # (~24%) at the previous 150 - enough cushion for the known
             # variance of shared macOS hosted runners without being
             # arbitrarily large. Re-tune if a real cold-cache release run
-            # comes in meaningfully over ~2h.
+            # comes in meaningfully over ~2h. Keep rust_targets/
+            # timeout_minutes here in sync with warm-release-cache.yml's
+            # macos entry by hand - see that file's comment for why.
             timeout_minutes: 180
             artifact_name: macos
     uses: ./.github/workflows/plugin-build-platform.yml

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -1,0 +1,91 @@
+name: Release plugin package
+
+# Builds the real shippable cross-platform release artifact via the reusable
+# per-platform build workflow (plugin-build-platform.yml) — release-lto
+# profile, genuine dual-arch/universal macOS binary, no CI-speed shortcuts —
+# and uploads each platform's output as a workflow artifact for the
+# merge/package/publish steps that follow.
+#
+# Two triggers, one pipeline:
+#   - push of a vX.Y.Z tag: a real release.
+#   - workflow_dispatch: a disposable dry run, used to validate this whole
+#     pipeline without cutting a real tag. Manual runs must supply a version
+#     with a SemVer pre-release/RC suffix (e.g. v0.3.0-rc1) so a disposable
+#     test run can never be mistaken for a real release version.
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to build, e.g. v0.3.0-rc1. Must include a SemVer pre-release/RC suffix (-rc1, -beta.1, ...)."
+        required: true
+        type: string
+
+jobs:
+  resolve-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+    steps:
+      - name: Resolve and validate version
+        id: resolve
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            version="${{ inputs.version }}"
+            if ! [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-[0-9A-Za-z][0-9A-Za-z.-]*$ ]]; then
+              echo "::error::Manual dispatch requires a version with a SemVer pre-release/RC suffix (e.g. v0.3.0-rc1) to keep disposable test runs distinct from real releases. Got: '$version'"
+              exit 1
+            fi
+          else
+            version="${{ github.ref_name }}"
+          fi
+          echo "Resolved release version: $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: resolve-version
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            platform_dir: addons/godot-lore-plugin/windows
+            rust_targets: ""
+            cmake_extra_args: ""
+            timeout_minutes: 90
+            artifact_name: windows
+          - os: ubuntu-latest
+            platform_dir: addons/godot-lore-plugin/linux
+            rust_targets: ""
+            cmake_extra_args: ""
+            timeout_minutes: 90
+            artifact_name: linux
+          - os: macos-latest
+            platform_dir: addons/godot-lore-plugin/macos
+            # No CMAKE_OSX_ARCHITECTURES override: CMakeLists.txt defaults to
+            # "x86_64;arm64", which is a real universal build (see its
+            # LORE_DUAL_ARCH handling) - unlike plugin-build.yml's CI
+            # validation matrix, which forces arm64-only for speed. Both
+            # Darwin targets must be installed for cargo to build each slice
+            # lipo then merges.
+            rust_targets: "x86_64-apple-darwin,aarch64-apple-darwin"
+            cmake_extra_args: ""
+            # Dual-arch release-lto easily exceeds CI validation's 60-minute
+            # budget; no real number is on record yet for this repo, so
+            # start generous and tune down once a real run's timing is known.
+            timeout_minutes: 150
+            artifact_name: macos
+    uses: ./.github/workflows/plugin-build-platform.yml
+    with:
+      os: ${{ matrix.os }}
+      platform_dir: ${{ matrix.platform_dir }}
+      cargo_profile: release-lto
+      rust_targets: ${{ matrix.rust_targets }}
+      cmake_extra_args: ${{ matrix.cmake_extra_args }}
+      timeout_minutes: ${{ matrix.timeout_minutes }}
+      upload_artifact: true
+      artifact_name: ${{ matrix.artifact_name }}

--- a/.github/workflows/pr-cache-cleanup.yml
+++ b/.github/workflows/pr-cache-cleanup.yml
@@ -1,0 +1,58 @@
+name: Clean up closed PR caches
+
+# Deletes caches scoped to a closed PR's refs/pull/<N>/merge ref. Nothing
+# else does this: GitHub has no automatic cache cleanup on branch/PR/tag
+# deletion for any ref type - only two backstops exist (7-day-unused
+# eviction, and LRU eviction once the repo's 10GB cache cap is hit), both
+# blind to which caches are actually dead weight.
+#
+# Runs on a schedule rather than pull_request/pull_request_target: a
+# pull_request-triggered job gets a read-only GITHUB_TOKEN for fork PRs, so
+# it can't delete their caches; pull_request_target fixes that but hands
+# full base-repo token access to an event any external contributor can
+# trigger at will. A scheduled sweep needs neither - it checks PR state
+# itself via a plain read call, so there's no elevated-trust trigger to
+# reason about at all.
+
+on:
+  schedule:
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      pull-requests: read
+    steps:
+      - name: Delete caches for closed PRs
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          mapfile -t refs < <(
+            gh cache list --repo "${{ github.repository }}" --limit 100 \
+              --json ref --jq '.[].ref' | sort -u
+          )
+
+          deleted_any=false
+          for ref in "${refs[@]}"; do
+            if [[ "$ref" =~ ^refs/pull/([0-9]+)/merge$ ]]; then
+              pr_number="${BASH_REMATCH[1]}"
+              state=$(gh pr view "$pr_number" --repo "${{ github.repository }}" --json state --jq .state)
+              if [ "$state" != "OPEN" ]; then
+                echo "Deleting caches for closed PR #$pr_number ($ref, state=$state)"
+                gh cache delete --all --ref "$ref" \
+                  --repo "${{ github.repository }}" \
+                  --succeed-on-no-caches
+                deleted_any=true
+              fi
+            fi
+          done
+
+          if [ "$deleted_any" = false ]; then
+            echo "No closed-PR-scoped caches found."
+          fi

--- a/.github/workflows/pr-cache-cleanup.yml
+++ b/.github/workflows/pr-cache-cleanup.yml
@@ -1,18 +1,20 @@
-name: Clean up closed PR caches
+name: Clean up closed PR and deleted branch caches
 
-# Deletes caches scoped to a closed PR's refs/pull/<N>/merge ref. Nothing
-# else does this: GitHub has no automatic cache cleanup on branch/PR/tag
-# deletion for any ref type - only two backstops exist (7-day-unused
-# eviction, and LRU eviction once the repo's 10GB cache cap is hit), both
-# blind to which caches are actually dead weight.
+# Deletes caches scoped to a closed PR's refs/pull/<N>/merge ref, or to a
+# refs/heads/<branch> whose branch no longer exists (e.g. a feature branch
+# after its PR merges and it gets deleted). Nothing else does this: GitHub
+# has no automatic cache cleanup on branch/PR/tag deletion for any ref type
+# - only two backstops exist (7-day-unused eviction, and LRU eviction once
+# the repo's 10GB cache cap is hit), both blind to which caches are
+# actually dead weight.
 #
 # Runs on a schedule rather than pull_request/pull_request_target: a
 # pull_request-triggered job gets a read-only GITHUB_TOKEN for fork PRs, so
 # it can't delete their caches; pull_request_target fixes that but hands
 # full base-repo token access to an event any external contributor can
-# trigger at will. A scheduled sweep needs neither - it checks PR state
-# itself via a plain read call, so there's no elevated-trust trigger to
-# reason about at all.
+# trigger at will. A scheduled sweep needs neither - it checks PR/branch
+# state itself via plain read calls, so there's no elevated-trust trigger
+# to reason about at all.
 
 on:
   schedule:
@@ -20,7 +22,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  cleanup:
+  cleanup-prs:
     runs-on: ubuntu-latest
     permissions:
       actions: write
@@ -55,4 +57,47 @@ jobs:
 
           if [ "$deleted_any" = false ]; then
             echo "No closed-PR-scoped caches found."
+          fi
+
+  cleanup-branches:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Delete caches for deleted branches
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          mapfile -t refs < <(
+            gh cache list --repo "${{ github.repository }}" --limit 100 \
+              --json ref --jq '.[].ref' | sort -u
+          )
+
+          deleted_any=false
+          for ref in "${refs[@]}"; do
+            # refs/heads/refs/tags/... is prerelease-cache-cleanup.yml's
+            # territory (the workflow_dispatch-against-a-tag-ref quirk it
+            # documents) - skip it here so this job never treats a
+            # protected release-tag cache as a "deleted branch".
+            if [[ "$ref" == refs/heads/refs/tags/* ]]; then
+              continue
+            fi
+            if [[ "$ref" =~ ^refs/heads/(.+)$ ]]; then
+              branch_name="${BASH_REMATCH[1]}"
+              if ! gh api "repos/${{ github.repository }}/branches/$branch_name" --silent 2>/dev/null; then
+                echo "Deleting caches for deleted branch: $branch_name ($ref)"
+                gh cache delete --all --ref "$ref" \
+                  --repo "${{ github.repository }}" \
+                  --succeed-on-no-caches
+                deleted_any=true
+              fi
+            fi
+          done
+
+          if [ "$deleted_any" = false ]; then
+            echo "No deleted-branch-scoped caches found."
           fi

--- a/.github/workflows/prerelease-cache-cleanup.yml
+++ b/.github/workflows/prerelease-cache-cleanup.yml
@@ -1,0 +1,62 @@
+name: Clean up pre-release tag caches
+
+# Sweeps caches scoped to disposable pre-release/RC tags (e.g. v0.3.0-rc1)
+# - the workflow_dispatch dry-run seam plugin-release.yml documents.
+# Deleting the tag itself does NOT clear its cache (confirmed by hand for
+# v0.3.0-rc1); GitHub has no automatic cache cleanup on branch/PR/tag
+# deletion for any ref type, same as pr-cache-cleanup.yml.
+#
+# Matches pre-release/RC tags only, via the same SemVer suffix pattern
+# plugin-release.yml's resolve-version job uses - a real vX.Y.Z release
+# tag's cache is never swept. Matches both observed ref shapes:
+# refs/tags/vX.Y.Z-rcN (a real tag push) and refs/heads/refs/tags/vX.Y.Z-rcN
+# (seen from a workflow_dispatch run pointed at a tag ref via --ref).
+#
+# Weekly, not per-push: these caches only accumulate from occasional manual
+# dry-run validation.
+
+on:
+  schedule:
+    - cron: "0 6 * * 0"
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Delete caches for pre-release/RC tag refs
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          # Same pattern as plugin-release.yml's resolve-version job.
+          semver_prerelease_re='^v[0-9]+\.[0-9]+\.[0-9]+-[0-9A-Za-z][0-9A-Za-z.-]*$'
+
+          # 100 comfortably covers this repo's cache count; the 10GB cap
+          # bounds it well below that regardless.
+          mapfile -t refs < <(
+            gh cache list --repo "${{ github.repository }}" --limit 100 \
+              --json ref --jq '.[].ref' | sort -u
+          )
+
+          deleted_any=false
+          for ref in "${refs[@]}"; do
+            tag_name="${ref#refs/tags/}"
+            tag_name="${tag_name#refs/heads/refs/tags/}"
+            if { [[ "$ref" == refs/tags/* ]] || [[ "$ref" == refs/heads/refs/tags/* ]]; } \
+              && [[ "$tag_name" =~ $semver_prerelease_re ]]; then
+              echo "Deleting caches for pre-release tag ref: $ref"
+              gh cache delete --all --ref "$ref" \
+                --repo "${{ github.repository }}" \
+                --succeed-on-no-caches
+              deleted_any=true
+            fi
+          done
+
+          if [ "$deleted_any" = false ]; then
+            echo "No pre-release/RC tag-scoped caches found."
+          fi

--- a/.github/workflows/warm-release-cache.yml
+++ b/.github/workflows/warm-release-cache.yml
@@ -1,0 +1,79 @@
+name: Warm release-lto lore cache
+
+# Populates the lore-artifact-<os>-<arch>-release-lto-<lore-sha> cache
+# (see plugin-build-platform.yml's "Restore/Save cached lore artifact"
+# steps) on main's cache scope, specifically so plugin-release.yml's real
+# release builds don't cold-start.
+#
+# actions/cache only restores a cache from the current ref, a PR's base
+# branch, or the repo's *default* branch - never from another branch or
+# tag's scope. Every real release is a `vX.Y.Z` tag push, and every such
+# tag is its own brand-new ref, so it can never inherit a release-lto
+# cache entry saved by a previous tag or by a workflow_dispatch dry run.
+# The default branch is the one scope every other ref can fall back to,
+# so this workflow's whole job is to make sure that scope has a hot entry
+# for the current Lore SHA before a release ever needs it.
+#
+# This narrows, but doesn't eliminate, the cold-cache case: it only helps
+# a release tag whose Lore SHA matches what main last warmed (true for
+# the normal "cut a release from current main" flow). A release cut
+# before this job has run for the current Lore SHA, or from a Lore SHA
+# that never landed on main, still cold-starts - plugin-release.yml's
+# timeout_minutes stays sized for that case regardless.
+#
+# Path-filtered to third_party/lore, rather than running on every push to
+# main: the cache key depends only on the Lore submodule's commit SHA and
+# the cargo profile, so a run triggered by anything else would just
+# restore-hit its own unchanged key and do nothing useful. Also filtered
+# on this workflow and plugin-build-platform.yml themselves (matching
+# plugin-build.yml's self-referential convention) so an edit to either
+# gets exercised immediately rather than waiting for the next Lore bump.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - third_party/lore
+      - .github/workflows/warm-release-cache.yml
+      - .github/workflows/plugin-build-platform.yml
+  workflow_dispatch:
+
+jobs:
+  warm:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            platform_dir: addons/godot-lore-plugin/windows
+            rust_targets: ""
+            cmake_extra_args: ""
+            timeout_minutes: 90
+          - os: ubuntu-latest
+            platform_dir: addons/godot-lore-plugin/linux
+            rust_targets: ""
+            cmake_extra_args: ""
+            timeout_minutes: 90
+          - os: macos-latest
+            platform_dir: addons/godot-lore-plugin/macos
+            # Real dual-arch/universal build, matching plugin-release.yml
+            # exactly - a cache built from the CI-validation matrix's
+            # arm64-only override would be a different, useless cache key
+            # for the release leg's purposes anyway (runner.arch doesn't
+            # vary by target arch, but the artifact under build/lore would
+            # be the wrong shape). Keep rust_targets/timeout_minutes here
+            # in sync with plugin-release.yml's macos entry by hand - no
+            # single source feeds both (unlike plugin-release.yml's own
+            # platform-directory glob in its package job, which only
+            # dedups within that one job/file).
+            rust_targets: "x86_64-apple-darwin,aarch64-apple-darwin"
+            cmake_extra_args: ""
+            timeout_minutes: 180
+    uses: ./.github/workflows/plugin-build-platform.yml
+    with:
+      os: ${{ matrix.os }}
+      platform_dir: ${{ matrix.platform_dir }}
+      cargo_profile: release-lto
+      rust_targets: ${{ matrix.rust_targets }}
+      cmake_extra_args: ${{ matrix.cmake_extra_args }}
+      timeout_minutes: ${{ matrix.timeout_minutes }}

--- a/scripts/verify-platform-package.sh
+++ b/scripts/verify-platform-package.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Verifies that a godot-lore-plugin platform directory (staged build output,
+# or an assembled release package's per-platform subfolder) contains the
+# expected files: the plugin's own build output and Lore's native shared
+# library. Filename-agnostic on both counts, since a single-arch macOS build
+# isn't named the same as the universal release artifact, and the Lore
+# library's filename differs per platform (lore.dll / liblore.so /
+# liblore.dylib).
+#
+# Usage: verify-platform-package.sh <platform_dir>
+set -euo pipefail
+
+platform_dir="$1"
+
+test -n "$(find "$platform_dir" -maxdepth 1 -iname 'godot-lore-plugin*' -print -quit)"
+test -n "$(find "$platform_dir" -maxdepth 1 \( -iname 'lore.dll' -o -iname 'liblore.*' \) -print -quit)"


### PR DESCRIPTION
This change adds workflows to automatically generate a compressed package file for the plugin and attach it to a draft Release that can be human reviewed before publishing. It includes cache management workflows to pre-warm the Lore submodule, and clean-up stale caches from closed PRs and throw-away pre-release tags on a schedule.