### PR TITLE
Strip debug info from Linux `liblore.so` in `build_lore_crate.cmake`

### DIFF
--- a/.github/workflows/plugin-build.yml
+++ b/.github/workflows/plugin-build.yml
@@ -20,6 +20,7 @@ on:
     paths:
       - src/**
       - CMakeLists.txt
+      - cmake/**
       - addons/godot-lore-plugin/godot-lore-plugin.gdextension
       - third_party/godot-cpp
       - third_party/lore
@@ -29,6 +30,7 @@ on:
     paths:
       - src/**
       - CMakeLists.txt
+      - cmake/**
       - addons/godot-lore-plugin/godot-lore-plugin.gdextension
       - third_party/godot-cpp
       - third_party/lore

--- a/cmake/build_lore_crate.cmake
+++ b/cmake/build_lore_crate.cmake
@@ -74,6 +74,19 @@ else()
     if(NOT LORE_CARGO_RESULT EQUAL 0)
         message(FATAL_ERROR "cargo build failed")
     endif()
+
+    if(UNIX AND NOT APPLE)
+        # Only the Windows/macOS Rust targets set split-debuginfo in
+        # third_party/lore's .cargo/config.toml, so the generic Linux
+        # build ships full embedded DWARF unless stripped here.
+        execute_process(
+            COMMAND strip --strip-debug "${LORE_CARGO_OUT_DIR}/${LORE_SHARED_LIB_NAME}"
+            RESULT_VARIABLE LORE_STRIP_RESULT
+        )
+        if(NOT LORE_STRIP_RESULT EQUAL 0)
+            message(FATAL_ERROR "strip failed")
+        endif()
+    endif()
 endif()
 
 execute_process(COMMAND "${CMAKE_COMMAND}" -E copy_if_different


### PR DESCRIPTION
This is a local patch until the upstream lore project has an official fix.

The Lore crate's Linux x86 build never splits/strips debug info the way Windows/macOS & ARM Linux cargo config does, via `split-debuginfo=packed`. Proposed upstream fix located at https://github.com/EpicGames/lore/pull/163.