### PR TITLE
Fix GDExtension load failure on Linux/macOS: missing soname and broken auto-rpath

### DIFF
--- a/.github/workflows/plugin-build-platform.yml
+++ b/.github/workflows/plugin-build-platform.yml
@@ -66,6 +66,13 @@ jobs:
         with:
           targets: ${{ inputs.rust_targets }}
 
+      # build_lore_crate.cmake uses patchelf to embed a soname into
+      # liblore.so (rustc's cdylib output has none on Linux) - not
+      # preinstalled on the runner image.
+      - name: Install patchelf
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y patchelf
+
       - name: Cache cargo registry and build artifacts
         uses: Swatinem/rust-cache@v2
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,16 @@ set_target_properties(
 )
 if(WIN32)
     set_target_properties(lore PROPERTIES IMPORTED_IMPLIB "${LORE_STAGE_DIR}/lib/lore.dll.lib")
+elseif(UNIX AND NOT APPLE)
+    # cargo's cdylib has no embedded DT_SONAME on Linux, so without this,
+    # CMake links godot-lore-plugin against lore's raw IMPORTED_LOCATION
+    # path, and that path (containing a slash) ends up baked into
+    # DT_NEEDED verbatim — which skips RPATH resolution entirely and
+    # breaks the load outside the build dir. This makes CMake link by
+    # bare name instead, so DT_NEEDED is plain "liblore.so" and $ORIGIN
+    # resolves it. (macOS sets its dylib's install name directly in
+    # third_party/lore/lore/build.rs instead; IMPORTED_SONAME is a no-op there.)
+    set_target_properties(lore PROPERTIES IMPORTED_SONAME "${LORE_SHARED_LIB_NAME}")
 endif()
 add_dependencies(lore lore_cargo_build)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,16 +121,6 @@ set_target_properties(
 )
 if(WIN32)
     set_target_properties(lore PROPERTIES IMPORTED_IMPLIB "${LORE_STAGE_DIR}/lib/lore.dll.lib")
-elseif(UNIX AND NOT APPLE)
-    # cargo's cdylib has no embedded DT_SONAME on Linux, so without this,
-    # CMake links godot-lore-plugin against lore's raw IMPORTED_LOCATION
-    # path, and that path (containing a slash) ends up baked into
-    # DT_NEEDED verbatim — which skips RPATH resolution entirely and
-    # breaks the load outside the build dir. This makes CMake link by
-    # bare name instead, so DT_NEEDED is plain "liblore.so" and $ORIGIN
-    # resolves it. (macOS sets its dylib's install name directly in
-    # third_party/lore/lore/build.rs instead; IMPORTED_SONAME is a no-op there.)
-    set_target_properties(lore PROPERTIES IMPORTED_SONAME "${LORE_SHARED_LIB_NAME}")
 endif()
 add_dependencies(lore lore_cargo_build)
 
@@ -174,12 +164,23 @@ get_target_property(GODOTCPP_SUFFIX godot-cpp GODOTCPP_SUFFIX)
 
 set(GODOT_LORE_PLUGIN_OUTPUT_DIR "${CMAKE_SOURCE_DIR}/addons/godot-lore-plugin/${GODOT_LORE_PLUGIN_PLATFORM_DIR}")
 
+# CMake's automatic rpath (BUILD_RPATH_USE_ORIGIN) points at lore's
+# build-tree location (IMPORTED_LOCATION), not where the POST_BUILD copy
+# below actually puts it — producing a build-relative RPATH on Linux and an
+# absolute CI-runner path on macOS, neither of which survive shipping. Set
+# it explicitly to just "look next to me" instead.
+if(APPLE)
+    set(GODOT_LORE_PLUGIN_BUILD_RPATH "@loader_path")
+elseif(UNIX)
+    set(GODOT_LORE_PLUGIN_BUILD_RPATH "$ORIGIN")
+endif()
+
 # gersemi: off
 set_target_properties(
     godot-lore-plugin
     PROPERTIES
         POSITION_INDEPENDENT_CODE ON
-        BUILD_RPATH_USE_ORIGIN ON
+        BUILD_RPATH "${GODOT_LORE_PLUGIN_BUILD_RPATH}"
 
         LINK_SEARCH_START_STATIC ON
         LINK_SEARCH_END_STATIC ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,15 +164,14 @@ get_target_property(GODOTCPP_SUFFIX godot-cpp GODOTCPP_SUFFIX)
 
 set(GODOT_LORE_PLUGIN_OUTPUT_DIR "${CMAKE_SOURCE_DIR}/addons/godot-lore-plugin/${GODOT_LORE_PLUGIN_PLATFORM_DIR}")
 
-# CMake's automatic rpath (BUILD_RPATH_USE_ORIGIN) points at lore's
-# build-tree location (IMPORTED_LOCATION), not where the POST_BUILD copy
-# below actually puts it — producing a build-relative RPATH on Linux and an
-# absolute CI-runner path on macOS, neither of which survive shipping. Set
-# it explicitly to just "look next to me" instead.
+# CMake's automatic rpath points at lore's build-tree location, not where
+# the POST_BUILD copy below actually puts it, and BUILD_RPATH only adds to
+# that rather than replacing it. SKIP_BUILD_RPATH below disables it so the
+# explicit -rpath flag is the only entry: "look next to me".
 if(APPLE)
-    set(GODOT_LORE_PLUGIN_BUILD_RPATH "@loader_path")
+    set(GODOT_LORE_PLUGIN_RPATH_FLAG "-Wl,-rpath,@loader_path")
 elseif(UNIX)
-    set(GODOT_LORE_PLUGIN_BUILD_RPATH "$ORIGIN")
+    set(GODOT_LORE_PLUGIN_RPATH_FLAG "-Wl,-rpath,$ORIGIN")
 endif()
 
 # gersemi: off
@@ -180,7 +179,7 @@ set_target_properties(
     godot-lore-plugin
     PROPERTIES
         POSITION_INDEPENDENT_CODE ON
-        BUILD_RPATH "${GODOT_LORE_PLUGIN_BUILD_RPATH}"
+        SKIP_BUILD_RPATH ON
 
         LINK_SEARCH_START_STATIC ON
         LINK_SEARCH_END_STATIC ON
@@ -193,6 +192,9 @@ set_target_properties(
         OUTPUT_NAME "godot-lore-plugin${GODOTCPP_SUFFIX}"
 )
 # gersemi: on
+if(GODOT_LORE_PLUGIN_RPATH_FLAG)
+    target_link_options(godot-lore-plugin PRIVATE "${GODOT_LORE_PLUGIN_RPATH_FLAG}")
+endif()
 
 # Lore's shared library is a runtime dependency of godot-lore-plugin's own
 # shared library; it must sit next to it for the loader to find it.

--- a/cmake/build_lore_crate.cmake
+++ b/cmake/build_lore_crate.cmake
@@ -86,6 +86,21 @@ else()
         if(NOT LORE_STRIP_RESULT EQUAL 0)
             message(FATAL_ERROR "strip failed")
         endif()
+
+        # rustc's cdylib has no embedded DT_SONAME on Linux (macOS gets the
+        # equivalent -install_name via third_party/lore's build.rs, upstream
+        # Epic code we can't patch). Without it, consumers linking by path
+        # bake that literal path into their own DT_NEEDED, which skips
+        # RPATH resolution at load time. Patch the soname in directly.
+        find_program(PATCHELF_EXECUTABLE patchelf REQUIRED)
+        execute_process(
+            COMMAND "${PATCHELF_EXECUTABLE}" --set-soname "${LORE_SHARED_LIB_NAME}"
+                "${LORE_CARGO_OUT_DIR}/${LORE_SHARED_LIB_NAME}"
+            RESULT_VARIABLE LORE_PATCHELF_RESULT
+        )
+        if(NOT LORE_PATCHELF_RESULT EQUAL 0)
+            message(FATAL_ERROR "patchelf --set-soname failed")
+        endif()
     endif()
 endif()
 


### PR DESCRIPTION
## Summary

The plugin's Linux GDExtension failed to load in the Godot editor with `cannot open shared object file: lore/bin/liblore.so`, even though `liblore.so` was present right next to the extension binary (#9). Two independent bugs, on two platforms:

- Linux: rustc's cdylib output has no embedded `SONAME`. Without one, the linker bakes the literal build-tree path used to reference `liblore.so` into `godot-lore-plugin`'s `DT_NEEDED` entry instead of a bare filename. A `DT_NEEDED` containing a slash skips `RPATH/RUNPATH` search entirely, so the loader tried to open a path relative to Godot's working directory rather than finding the file that was actually right there.
- Linux + macOS: CMake's automatic build-tree rpath computation points at where liblore lives during the build, not where the plugin's own `POST_BUILD` step copies it to (alongside the shipped extension). This produced a build-relative `RUNPATH` on Linux and a hardcoded absolute CI-runner path baked into macOS's `RPATH` — neither survives being unzipped on an end user's machine.

## Fix

- `cmake/build_lore_crate.cmake`: patch a real `SONAME` (`liblore.so`) onto the built shared library via `patchelf`, since `third_party/lore` is Epic's upstream submodule and we can't add the equivalent of macOS's existing `-install_name` rustc flag there.
- `CMakeLists.txt`: disable CMake's automatic rpath computation (`SKIP_BUILD_RPATH ON`) and set the runtime search path explicitly via a raw linker flag (`-rpath $ORIGIN` / `-rpath @loader_path`), so the shipped binary only ever looks next to itself.
- `.github/workflows/plugin-build-platform.yml`: install `patchelf` on the Linux CI leg.

## Verification

Built and downloaded real CI artifacts (not just local reasoning) and confirmed on both platforms:
- Linux: `DT_NEEDED [liblore.so]`, `RUNPATH [$ORIGIN]`, and the extension actually `dlopen`s successfully from an unrelated working directory (reproducing the original bug's WSL scenario).
- Linux: Installed Godot 4.7.1 Linux x64 into a WSL Ubuntu instance, installed the plugin into the project, and performed manual smoke tests of the full feature surface of the plugin.
- macOS: `LC_LOAD_DYLIB @rpath/liblore.dylib`, single clean `RPATH`: @loader_path entry, no leaked build-machine paths.

Closes #9.